### PR TITLE
add focus on show doc

### DIFF
--- a/cpp/source/basics/program_options.md
+++ b/cpp/source/basics/program_options.md
@@ -103,6 +103,12 @@ polyscope::init();
 
     If this option is `true`, the scene will be redrawn on every main loop iteration no matter what, circumventing the lazy drawing features. Default: `false`.
 
+??? func "`#!cpp bool options::giveFocusOnShow`"
+    
+    ##### give focus on show
+
+    If this option is `true`, the rendering window will be given focus when `polyscope::show()` is called.  Default: `false`.
+
 ??? func "`#!cpp bool options::buildGui`"
     
     ##### build gui

--- a/py/source/basics/program_options.md
+++ b/py/source/basics/program_options.md
@@ -104,3 +104,10 @@ ps.init()
     Polyscope is designed to use lazy rendering: the scene is only re-drawn if it has changed since the last time it was drawn. This can dramatically reduce resource consumption, and keeps the immediate GUI responsive even on scenes which are irresponsibly large for the machine's graphics capabilities.
 
     If this option is `True`, the scene will be redrawn on every main loop iteration no matter what, circumventing the lazy drawing features. Default: `False`.
+
+
+??? func "`#!python set_give_focus_on_show(b)`"
+    
+    ##### give focus on show
+
+    If this option is `true`, the rendering window will be given focus when `polyscope::show()` is called.  Default: `false`.


### PR DESCRIPTION
Add documentation of the `focusOnShow` C++ and Python bindings.  Note the change in the Python binding name, addressed in https://github.com/nmwsharp/polyscope-py/pull/7 .