### PR TITLE
Add edge permutation to example code

### DIFF
--- a/py/source/structures/surface_mesh/scalar_quantities.md
+++ b/py/source/structures/surface_mesh/scalar_quantities.md
@@ -25,6 +25,7 @@ ps_mesh.add_scalar_quantity("rand vals2", vals_face, defined_on='faces')
 
 # visualize some random data per-edge (halfedges are also supported)
 vals_edge = np.random.rand(ps_mesh.n_edges())
+ps_mesh.set_edge_permutation(np.arange(ps_mesh.n_edges())) # set permutations so edge data is meaningful
 ps_mesh.add_scalar_quantity("rand vals3", vals_edge, defined_on='edges')
 
 # as always, we can customize the initial appearance


### PR DESCRIPTION
In the example code for ```py/structures/surface_mesh/scalar_quantities``` we need to set the edge permutation before displaying any edge-based quantity, otherwise Polyscope will return the following error:
```
[EXCEPTION] SurfaceMesh rand vals3 attempted to set edge-valued data, but this requires an edge ordering. Call setEdgePermutation().
```