### PR TITLE
Only select face if ImGui does not handle mouse event

### DIFF
--- a/cpp/source/basics/interactive_UIs_and_animation.md
+++ b/cpp/source/basics/interactive_UIs_and_animation.md
@@ -246,7 +246,7 @@ myMesh->setSelectionMode(MeshSelectionMode::FacesOnly);
 
 // get the mouse location from ImGui
 ImGuiIO& io = ImGui::GetIO();
-if (io.MouseClicked[0]) { // if clicked
+if (io.MouseClicked[0] && !io.WantCaptureMouse) { // if clicked
   glm::vec2 screenCoords{io.MousePos.x, io.MousePos.y};
   polyscope::PickResult pickResult = polyscope::pickAtScreenCoords(screenCoords);
 


### PR DESCRIPTION
Documentation of the field:
> Set when Dear ImGui will use mouse inputs, in this case do not dispatch them to your main game/application (either way, always pass on mouse inputs to imgui). (e.g. unclicked mouse is hovering over an imgui window, widget is active, mouse was clicked over an imgui window, etc.).
 
This prevents clicks through menus.